### PR TITLE
Avoid big multiline titles

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -69,7 +69,8 @@ func Error(level string, err error) {
 // ErrorWithStackSkip asynchronously sends an error to Rollbar with the given
 // severity level and a given number of stack trace frames skipped.
 func ErrorWithStackSkip(level string, err error, skip int) {
-	body := buildBody(level, err.Error())
+	parts := strings.SplitN(err.Error(), "\n", 2)
+	body := buildBody(level, parts[0])
 	data := body["data"].(map[string]interface{})
 	errBody, fingerprint := errorBody(err, skip)
 	data["body"] = errBody
@@ -83,7 +84,8 @@ func ErrorWithStackSkip(level string, err error, skip int) {
 // Message asynchronously sends a message to Rollbar with the given severity
 // level. Rollbar request is asynchronous.
 func Message(level string, msg string) {
-	body := buildBody(level, msg)
+	parts := strings.SplitN(msg, "\n", 2)
+	body := buildBody(level, parts[0])
 	data := body["data"].(map[string]interface{})
 	data["body"] = messageBody(msg)
 


### PR DESCRIPTION
Hi,

I think is not the best approach to solve the problem, but basically, would be awesome find a way to let's the user customize:
- Title
- Body
- Stacktrace

I didn't had the time to come up with a clever solution but at least this seems to solve some problems where the  `error.Error()` is quite big.

To give you some context basically my apps generally have one file main/manager that handle errors/logs etc...
