### PR TITLE
Add RequestError method to pass along request attributes

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -3,6 +3,7 @@ package rollbar
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"testing"
 )
@@ -67,4 +68,66 @@ func TestEverything(t *testing.T) {
 	// If you don't see the message sent on line 65 in Rollbar, that means this
 	// is broken:
 	Wait()
+}
+
+func TestErrorRequest(t *testing.T) {
+	r, _ := http.NewRequest("GET", "http://foo.com/somethere?param1=true", nil)
+	r.RemoteAddr = "1.1.1.1:123"
+
+	object := errorRequest(r)
+
+	if object["url"] != "http://foo.com/somethere?param1=true" {
+		t.Errorf("wrong url, got %v", object["url"])
+	}
+
+	if object["method"] != "GET" {
+		t.Errorf("wrong method, got %v", object["method"])
+	}
+
+	if object["query_string"] != "param1=true" {
+		t.Errorf("wrong id, got %v", object["query_string"])
+	}
+}
+
+func TestScrubValues(t *testing.T) {
+	values := map[string][]string{
+		"password":     []string{"one"},
+		"toallyfine":   []string{"one"},
+		"sswo":         []string{"one"},
+		"access_token": []string{"one"},
+	}
+
+	scrubbed := scrubValues(values)
+	if scrubbed["password"][0] != "------" {
+		t.Error("should scrub password parameter")
+	}
+
+	if scrubbed["toallyfine"][0] == "------" {
+		t.Error("should keep toallyfine parameter")
+	}
+
+	// substring of scrubField
+	if scrubbed["sswo"][0] == "------" {
+		t.Error("should keep sswo parameter")
+	}
+
+	if scrubbed["access_token"][0] != "------" {
+		t.Error("should keep access_token parameter")
+	}
+}
+
+func TestFlattenValues(t *testing.T) {
+	values := map[string][]string{
+		"a": []string{"one"},
+		"b": []string{"one", "two"},
+	}
+
+	flattened := flattenValues(values)
+	if flattened["a"].(string) != "one" {
+		t.Error("should flatten single parameter to string")
+	}
+
+	if len(flattened["b"].([]string)) != 2 {
+		t.Error("should leave multiple parametres as []string")
+	}
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestBuildStack(t *testing.T) {
 	frame := BuildStack(1)[0]
-	if frame.Filename != "github.com/stvp/rollbar/stack_test.go" {
+	if frame.Filename != "github.com/paulmach/rollbar/stack_test.go" {
 		t.Errorf("got: %s", frame.Filename)
 	}
 	if frame.Method != "rollbar.TestBuildStack" {


### PR DESCRIPTION
For "web apps" it would be nice to pass along information about the request to rollbar for indexing and such.

This PR adds two methods `RequestError` and `RequestErrorWithStackSkip`. They are the same as the existing similar methods, but add the request as the first parameter and populate the data to be sent to Rollbar. Populated fields includes: url, method, query_string headers, and post data.

The [Rollbar item post documentation](https://rollbar.com/docs/api/items_post/), for reference.
