### PR TITLE
Use external stack and allow custom fields for body

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -125,3 +125,41 @@ func TestFlattenValues(t *testing.T) {
 		t.Error("should leave multiple parametres as []string")
 	}
 }
+
+func TestCustomField(t *testing.T) {
+	body := buildError(ERR, errors.New("test-custom"), BuildStack(0), &Field{
+		Name: "custom",
+		Data: map[string]string{
+			"NAME1": "VALUE1",
+		},
+	})
+
+	dataField, ok := body["data"]
+	if !ok {
+		t.Error("should have field 'data'")
+	}
+
+	data, ok := dataField.(map[string]interface{})
+	if !ok {
+		t.Error("should be of type map[string]interface{}")
+	}
+
+	custom, ok := data["custom"]
+	if !ok {
+		t.Error("should have field 'custom'")
+	}
+
+	customMap, ok := custom.(map[string]string)
+	if !ok {
+		t.Error("should be a map[string]string")
+	}
+
+	val, ok := customMap["NAME1"]
+	if !ok {
+		t.Error("should have a key 'NAME1'")
+	}
+
+	if val != "VALUE1" {
+		t.Error("should be VALUE1")
+	}
+}


### PR DESCRIPTION
In this commit two things have been added to the package,
none of them is changing the API, so it is completely
compatible for existing users.
## Use a custom stack

Two functions have been added
- `ErrorWithStack`
- `RequestErrorWithStack`

Those functions are working as `Error`, `RequestError` etc.
except that we can give them a custom stack.

Use case:

https://github.com/Soulou/errgo-rollbar

Basically with a web service which has a error management middleware.
If an error is returned to the middleware, I don't care to have the
stack of the middleware, what I'm interested in is the origin of the
error. Combined with errgo, it does exactly that.
## Add custom fields to the rollbar body

The client does not manage all the possibilities provided by the rollbar
API. That's why I've added as optional variadic argument "fields" to the
`Error`-ish functions, as result it is possible to use the `custom` or
the `person` attributes of the rollbar body

Example:

``` go
rollbar.Error(rollbar.ERR, err, &rollbar.Field{
  Name: "person",
  Data: map[string]string{
    "id": user.ID,
    "username": user.Username,
    "email": user.Email,
  },
})
```

As a consequence, the 'request' object is now using this
mecanism instead of having its custom code. (The `RequestError`
functions have been kept of course)

I hope these feature are OK for you, otherwise, what can I change, thanks !
