### PR TITLE
implemented error reporting as discussed in issue #11

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,21 @@
+package rollbar
+
+import (
+	"fmt"
+)
+
+// ErrNoToken is returned when trying to send a message to the rollbar service,
+// while not having the token initialized.
+type ErrNoToken struct{}
+
+// Error implements the error interface.
+func (e ErrNoToken) Error() string {
+	return "rollbar: No token set."
+}
+
+type ErrHttpError int
+
+// Error implements the error interface.
+func (e ErrHttpError) Error() string {
+	return fmt.Sprintf("rollbar: The rollbar service replied with %d http status code.", e)
+}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -163,3 +163,32 @@ func TestCustomField(t *testing.T) {
 		t.Error("should be VALUE1")
 	}
 }
+
+func TestErrorRead(t *testing.T) {
+	Token = os.Getenv("TOKEN")
+	Environment = "test"
+
+	bckBuffer, bckEP := Buffer, Endpoint
+	defer func() {
+		Buffer, Endpoint = bckBuffer, bckEP
+	}()
+
+	Buffer = 2
+	Endpoint = "https://does.not.exsist/foo/bar"
+
+	go func() {
+		errCount := 0
+		for err := range SendErrors() {
+			t.Log(err)
+			errCount++
+		}
+		if errCount != 2 {
+			t.Fatal("didn't receive the right number of errors", errCount)
+		}
+	}()
+
+	post(nil)
+	post(nil)
+
+	Wait()
+}


### PR DESCRIPTION
post() returns an error now. The returned errors use exported types to enable type-switching over them.

The errors are pushed to queueErrors (chan error) which can be obtained (read only) via SendErrors().

If queueErrors buffer is full it drops the oldest remaining error and therefore accomodates the newest one.

Added a unit test, to verify basic functionality works as expected. 