### PR TITLE
fix var declaration

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -173,7 +173,7 @@ func buildBody(level, title string) map[string]interface{} {
 	timestamp := time.Now().Unix()
 	hostname, _ := os.Hostname()
 
-	data = map[string]interface{}{
+	data := map[string]interface{}{
 		"environment": Environment,
 		"title":       title,
 		"level":       level,


### PR DESCRIPTION
Oops, sorry for the noise. I dropped the colon on the var declaration. This fixes that.