### PR TITLE
Custom fields no longer ignored

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -121,7 +121,7 @@ func RequestErrorWithStackSkip(level string, r *http.Request, err error, skip in
 // http.Request, and a custom Stack. You You can pass, optionally, custom
 // Fields to be passed on to Rollbar.
 func RequestErrorWithStack(level string, r *http.Request, err error, stack Stack, fields ...*Field) {
-	buildAndPushError(level, err, stack, &Field{Name: "request", Data: errorRequest(r)})
+	buildAndPushError(level, err, stack, append(fields, &Field{Name: "request", Data: errorRequest(r)})...)
 }
 
 func buildError(level string, err error, stack Stack, fields ...*Field) map[string]interface{} {
@@ -219,7 +219,8 @@ func errorRequest(r *http.Request) map[string]interface{} {
 		"GET":          flattenValues(cleanQuery),
 
 		// POST / PUT params
-		"POST": flattenValues(filterParams(r.Form)),
+		"POST":    flattenValues(filterParams(r.Form)),
+		"user_ip": r.RemoteAddr,
 	}
 }
 


### PR DESCRIPTION
Custom fields passed into RequestErrorWithStack are currently overwritten and completely ignored. This appends the new request field to the existing list.