### PR TITLE
Default message for nil errors

### DIFF
--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -126,6 +126,11 @@ func TestFlattenValues(t *testing.T) {
 	}
 }
 
+func TestBuildError(t *testing.T) {
+	body := buildError(ERR, nil, BuildStack(0))
+	// this should not panic
+}
+
 func TestCustomField(t *testing.T) {
 	body := buildError(ERR, errors.New("test-custom"), BuildStack(0), &Field{
 		Name: "custom",


### PR DESCRIPTION
I found myself passing in a nil error on accident and the code paniced. This PR handles nil errors and sets their title to "<nil>".