### PR TITLE
Added Errorf function

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -80,6 +80,10 @@ func init() {
 
 // -- Error reporting
 
+func Errorf(level string, format string, args ...interface{}) {
+	ErrorWithStackSkip(level, fmt.Errorf(format, args), 1)
+}
+
 // Error asynchronously sends an error to Rollbar with the given severity
 // level. You can pass, optionally, custom Fields to be passed on to Rollbar.
 func Error(level string, err error, fields ...*Field) {


### PR DESCRIPTION
Since the `Message` function does not include stack traces my team uses the `rollbar.Error` function a lot with `fmt.Errorf`, to log events that don't produce `error`s in the golang sense.

Some library support for it would be nice, I think it might also be useful to others.