### PR TITLE
Modified to able to set http.Client

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -83,6 +83,7 @@ var (
 	waitGroup   sync.WaitGroup
 	postErrors  chan error
 	nilErrTitle = "<nil>"
+	Client = http.DefaultClient
 )
 
 // Field is a custom data field used to report arbitrary data to the Rollbar
@@ -361,7 +362,7 @@ func post(body map[string]interface{}) error {
 		return err
 	}
 
-	resp, err := http.Post(Endpoint, "application/json", bytes.NewReader(jsonBody))
+	resp, err := Client.Post(Endpoint, "application/json", bytes.NewReader(jsonBody))
 	if err != nil {
 		stderr("POST failed: %s", err.Error())
 		return err


### PR DESCRIPTION
Support GoogleAppEngine library [urlfetch](https://godoc.org/google.golang.org/appengine/urlfetch).

See https://cloud.google.com/appengine/docs/go/urlfetch/