### PR TITLE
Fix Errorf argument passing to fmt.Errorf

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -117,7 +117,7 @@ func init() {
 // -- Error reporting
 
 func Errorf(level string, format string, args ...interface{}) {
-	ErrorWithStackSkip(level, fmt.Errorf(format, args), 1)
+	ErrorWithStackSkip(level, fmt.Errorf(format, args...), 1)
 }
 
 // Error asynchronously sends an error to Rollbar with the given severity


### PR DESCRIPTION
Should be `fmt.Errorf(format, args...)`

Using:
```
	var in = []interface{}{
		"string",
		0,
		true,
	}

	fmt.Printf("%s %d %v\n", in)
	fmt.Printf("%s %d %v\n", in...)
```

Results:
```
[string %!s(int=0) %!s(bool=true)] %!d(MISSING) %!v(MISSING)
string 0 true
```