### PR TITLE
always close response body

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -366,14 +366,11 @@ func post(body map[string]interface{}) error {
 		stderr("POST failed: %s", err.Error())
 		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		stderr("received response: %s", resp.Status)
 		return ErrHTTPError(resp.StatusCode)
-	}
-
-	if resp != nil {
-		resp.Body.Close()
 	}
 
 	return nil


### PR DESCRIPTION
If for any reason a request fails this will prevent the leakage of file descriptors