### PR TITLE
stop generating a custom error grouping fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Other Resources
 For best practices and more information on how to handle errors in Go, these are
 some great places to get started:
 
-[Error Handling in Go](https://blog.golang.org/error-handling-and-go)
-[Why does Go not have exceptions?](https://golang.org/doc/faq#exceptions)
-[Defer, Panic and Recover](https://blog.golang.org/defer-panic-and-recover)
-[pkg/errors](https://github.com/pkg/errors)
+* [Error Handling in Go](https://blog.golang.org/error-handling-and-go)
+* [Why does Go not have exceptions?](https://golang.org/doc/faq#exceptions)
+* [Defer, Panic and Recover](https://blog.golang.org/defer-panic-and-recover)
+* [pkg/errors](https://github.com/pkg/errors)
 
 Contributors
 ============

--- a/stack.go
+++ b/stack.go
@@ -1,8 +1,6 @@
 package rollbar
 
 import (
-	"fmt"
-	"hash/crc32"
 	"os"
 	"runtime"
 	"strings"
@@ -41,17 +39,6 @@ func BuildStack(skip int) Stack {
 	}
 
 	return stack
-}
-
-// Fingerprint builds a string that uniquely identifies a Rollbar item using
-// the full stacktrace. The fingerprint is used to ensure (to a reasonable
-// degree) that items are coalesced by Rollbar in a smart way.
-func (s Stack) Fingerprint() string {
-	hash := crc32.NewIEEE()
-	for _, frame := range s {
-		fmt.Fprintf(hash, "%s%s%d", frame.Filename, frame.Method, frame.Line)
-	}
-	return fmt.Sprintf("%x", hash.Sum32())
 }
 
 // Remove un-needed information from the source file path. This makes them

--- a/stack_test.go
+++ b/stack_test.go
@@ -17,40 +17,6 @@ func TestBuildStack(t *testing.T) {
 	}
 }
 
-func TestStackFingerprint(t *testing.T) {
-	tests := []struct {
-		Fingerprint string
-		Stack       Stack
-	}{
-		{
-			"9344290d",
-			Stack{
-				Frame{"foo.go", "Oops", 1},
-			},
-		},
-		{
-			"a4d78b7",
-			Stack{
-				Frame{"foo.go", "Oops", 2},
-			},
-		},
-		{
-			"50e0fcb3",
-			Stack{
-				Frame{"foo.go", "Oops", 1},
-				Frame{"foo.go", "Oops", 2},
-			},
-		},
-	}
-
-	for i, test := range tests {
-		fingerprint := test.Stack.Fingerprint()
-		if fingerprint != test.Fingerprint {
-			t.Errorf("tests[%d]: got %s", i, fingerprint)
-		}
-	}
-}
-
 func TestShortenFilePath(t *testing.T) {
 	tests := []struct {
 		Given    string


### PR DESCRIPTION
we've been experiencing errors getting grouped together: our errors tend to be generated from the same locations in our codebase. the stack trace generated by stvp/rollbar in that case will be identical, but the actual cause for the error could be much different. 

according to their [docs](https://rollbar.com/docs/grouping-algorithm/), rollbar generates a much more sophisticated grouping fingerprint on their server that takes into account the error class as well as the stack (but throws away line numbers). we'd like to use that default grouping algorithm instead, so we'd like to make supplying a fingerprint optional.