### PR TITLE
adding BuildStackWithCallers

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -41,6 +41,20 @@ func BuildStack(skip int) Stack {
 	return stack
 }
 
+// BuildStackWithCallers builds a full stackstrace from the given list of callees.
+func BuildStackWithCallers(callers []uintptr) Stack {
+	stack := make(Stack, 0, len(callers))
+
+	for _, caller := range callers {
+		if fn := runtime.FuncForPC(caller); fn != nil {
+			file, line := fn.FileLine(caller)
+			stack = append(stack, Frame{shortenFilePath(file), functionNameFromFunc(fn), line})
+		}
+	}
+
+	return stack
+}
+
 // Remove un-needed information from the source file path. This makes them
 // shorter in Rollbar UI as well as making them the same, regardless of the
 // machine the code was compiled on.
@@ -62,12 +76,15 @@ func shortenFilePath(s string) string {
 	return s
 }
 
-func functionName(pc uintptr) string {
-	fn := runtime.FuncForPC(pc)
+func functionNameFromFunc(fn *runtime.Func) string {
 	if fn == nil {
 		return "???"
 	}
 	name := fn.Name()
 	end := strings.LastIndex(name, string(os.PathSeparator))
 	return name[end+1 : len(name)]
+}
+
+func functionName(pc uintptr) string {
+	return functionNameFromFunc(runtime.FuncForPC(pc))
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,19 +1,36 @@
 package rollbar
 
 import (
+	"runtime"
 	"testing"
 )
 
 func TestBuildStack(t *testing.T) {
 	frame := BuildStack(1)[0]
 	if frame.Filename != "github.com/stvp/rollbar/stack_test.go" {
-		t.Errorf("got: %s", frame.Filename)
+		t.Errorf("got filename: %s", frame.Filename)
 	}
 	if frame.Method != "rollbar.TestBuildStack" {
-		t.Errorf("got: %s", frame.Method)
+		t.Errorf("got method: %s", frame.Method)
 	}
-	if frame.Line != 8 {
-		t.Errorf("got: %d", frame.Line)
+	if frame.Line != 9 {
+		t.Errorf("got line: %d", frame.Line)
+	}
+}
+
+func TestBuildStackWithCallers(t *testing.T) {
+	callers := make([]uintptr, 2)
+	runtime.Callers(1, callers)
+
+	frame := BuildStackWithCallers(callers)[0]
+	if frame.Filename != "github.com/stvp/rollbar/stack_test.go" {
+		t.Errorf("got filename: %s", frame.Filename)
+	}
+	if frame.Method != "rollbar.TestBuildStackWithCallers" {
+		t.Errorf("got method: %s", frame.Method)
+	}
+	if frame.Line != 22 {
+		t.Errorf("got line: %d", frame.Line)
 	}
 }
 


### PR DESCRIPTION
Adding support for building a stack from a list of callers.

This allows capturing the callers list when creating an error to send it to rollbar up the chain. For example in an error handler middleware without having the stack trace being the one from the rollbar call itself but the one from the error.

Similar to https://github.com/stvp/roll but allows to use all of https://github.com/stvp/rollbar goodies as well.

A typical use case would be using the pkg/errors errors which keeps track of the callers for every error:
```
type stackTracer interface {
	StackTrace() []uintptr
}

func rollbarError(err error) {
	if st, ok := err.(stackTracer); ok {
		callers := st.StackTrace()
                stack := BuildStackWithCallers(callers)
                rollbar.ErrorWithStack("error", err, stack)
                return
	}
        rollbar.Error("error", err)
}
```

Other similar implementations of this in the wild:
* https://github.com/bjyoungblood/rollbar/commit/407805fc4a9fc8a009f5985f01d9609be8d0b258 