### PR TITLE
Use Rollbar constants instead of string

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ func main() {
   }
 
   // Message reporting
-  rollbar.Message("info", "Message body goes here")
+  rollbar.Message(rollbar.INFO, "Message body goes here")
 
   // Block until all queued messages are sent to Rollbar.
   // You can do this in a defer() if needed.


### PR DESCRIPTION
It's just a small change, but, always better use a constant instead of a string for this kind of use.