### PR TITLE
Updated VERSION

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -23,7 +23,7 @@ const (
 
 	// VERSION is the version number of this notifier library as reported to the
 	// Rollbar API.
-	VERSION = "0.4.0"
+	VERSION = "0.5.1"
 
 	// CRIT is the critical Rollbar severity level as reported to the Rollbar
 	// API.


### PR DESCRIPTION
From my understanding, the `VERSION` constant should reflect the current version of the library, which is now at 0.5.1 (b20261800d8cda3be14dcef0d1a8320779bba61a).