### PR TITLE
Fix frame line for BuildStackWithCallers test

### DIFF
--- a/stack_test.go
+++ b/stack_test.go
@@ -29,7 +29,7 @@ func TestBuildStackWithCallers(t *testing.T) {
 	if frame.Method != "rollbar.TestBuildStackWithCallers" {
 		t.Errorf("got method: %s", frame.Method)
 	}
-	if frame.Line != 22 {
+	if frame.Line != 25 {
 		t.Errorf("got line: %d", frame.Line)
 	}
 }


### PR DESCRIPTION
Previously this test was failing. It looks like an extra condition on
TestBuildStack was added after this test was implemented, skewing the
count.