### PR TITLE
Use actual error class name for default error type

### DIFF
--- a/rollbar.go
+++ b/rollbar.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"hash/adler32"
 	"io"
 	"net/http"
 	"net/url"
@@ -330,9 +329,6 @@ func errorClass(err error) string {
 	class := reflect.TypeOf(err).String()
 	if class == "" {
 		return "panic"
-	} else if class == "*errors.errorString" {
-		checksum := adler32.Checksum([]byte(err.Error()))
-		return fmt.Sprintf("{%x}", checksum)
 	} else {
 		return strings.TrimPrefix(class, "*")
 	}

--- a/rollbar_test.go
+++ b/rollbar_test.go
@@ -34,7 +34,9 @@ func testErrorStackWithSkip2(s string) {
 
 func TestErrorClass(t *testing.T) {
 	errors := map[string]error{
-		"{508e076d}":          fmt.Errorf("Something is broken!"),
+		// generic error
+		"errors.errorString":          fmt.Errorf("Something is broken!"),
+		// custom error
 		"rollbar.CustomError": &CustomError{"Terrible mistakes were made."},
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/stvp/rollbar/issues/42

Grouping in the dashboard gets scrambled when sending hash strings as the error class. The current Rollbar grouping logic is smart enough to use back trace and other signals to bucket these.